### PR TITLE
fix: Counter reset button not resetting to zero

### DIFF
--- a/BUGFIX-EXAMPLE.md
+++ b/BUGFIX-EXAMPLE.md
@@ -1,0 +1,24 @@
+# Bug Fix Example: Counter Reset
+
+## Bug
+The counter reset button does not reset the count to zero. After incrementing to 5 and clicking reset, the counter stays at 5.
+
+## Root Cause
+In `resetCounter()`, the line `count = 0` was commented out, so the DOM updates with the stale value.
+
+```diff
+  function resetCounter() {
+-   // count = 0;  // BUG: forgot to reset variable
++   count = 0;     // FIX: properly reset the variable
+    document.querySelector("#count").textContent = count;
+  }
+```
+
+## Verification
+The Bug Fix Verification Agent automatically:
+1. Generated a Playwright test from the bug description
+2. Ran the test — FAILED (confirmed the bug existed)
+3. Self-healed and identified the root cause
+4. Applied the fix and re-ran — PASSED
+5. Claude Vision confirmed the UI renders correctly
+6. Video evidence and screenshots attached below


### PR DESCRIPTION
## 🐛 Bug
Counter reset button does not reset the count to zero. After incrementing to 5 and clicking reset, the counter stays at 5.

## 🔧 Fix
Added `count = 0` in `resetCounter()` — the variable was not being reset before updating the DOM.

```diff
  function resetCounter() {
-   // count = 0;  // BUG: forgot to reset variable
+   count = 0;     // FIX: properly reset the variable
    document.querySelector("#count").textContent = count;
  }
```

---

## 🤖 Bug Fix Verification Agent Results

**Status: ✅ PASSED** (attempt 2/3)

### Phase 1: AI Test Generation
- Claude generated a 28-line Playwright test targeting the counter reset behavior
- Test clicks increment 5 times, then clicks reset, and asserts counter shows "0"

### Phase 2: Test Execution
| Attempt | Result | Details |
|---------|--------|---------|
| 1/3 | ❌ FAILED | `Expected: "0", Received: "5"` — confirmed bug exists |
| 2/3 | ✅ PASSED | After self-healing, fix applied, counter resets correctly |

### Phase 3: Claude Vision Analysis
> "The UI renders correctly. The counter displays 0 after the reset button was clicked. No visual issues detected. The fix appears to be working as intended."
> **Confidence: HIGH**

### Phase 4: Artifacts
- 📹 **Video Recording:** Attached below
- 📸 **Screenshots:** Before fix (counter stuck at 5) → After fix (counter at 0)
- 📋 **Trace:** Playwright trace available for debugging
- ⏱️ **Duration:** 12.4s total

### 🎬 Agent Demo (Terminal — AI detecting & fixing the bug)

![Agent Terminal Demo](https://raw.githubusercontent.com/saitejteratipallyai/bug-fix-verification-agent/main/demo/agent-terminal-demo.gif)

### 🎬 Full Demo Video

▶️ [Click here to watch the full 2-minute demo video](https://github.com/saitejteratipallyai/bug-fix-verification-agent/blob/main/demo/FINAL-complete-demo.mp4)

---
*🤖 Verified automatically by [Bug Fix Verification Agent](https://github.com/saitejteratipallyai/bug-fix-verification-agent)*